### PR TITLE
Fix duplicate calls to paginated endpoints.

### DIFF
--- a/ctxaws.go
+++ b/ctxaws.go
@@ -79,7 +79,7 @@ func prepareContext(ctx context.Context, req *request.Request) error {
 
 	req.Handlers.Send.Remove(corehandlers.SendHandler)
 	req.Handlers.Send.PushBack(sendHandler)
-	req.Retryer = NewContextAwareRetryer(ctx)
+	req.Retryer = NewContextAwareRetryer(ctx, req.Retryer)
 
 	return nil
 }

--- a/ctxaws.go
+++ b/ctxaws.go
@@ -23,6 +23,14 @@ import (
 // request, the send handler uses the x/net/context/ctxhttp package to do this while respecting the
 // context's deadline.
 func InContext(ctx context.Context, req *request.Request) error {
+	if err := prepareContext(ctx, req); err != nil {
+		return err
+	}
+
+	return req.Send()
+}
+
+func prepareContext(ctx context.Context, req *request.Request) error {
 	sendHandler := func(r *request.Request) {
 		var reStatusCode = regexp.MustCompile(`^(\d{3})`)
 		var err error
@@ -72,5 +80,6 @@ func InContext(ctx context.Context, req *request.Request) error {
 	req.Handlers.Send.Remove(corehandlers.SendHandler)
 	req.Handlers.Send.PushBack(sendHandler)
 	req.Retryer = NewContextAwareRetryer(ctx)
-	return req.Send()
+
+	return nil
 }

--- a/pagination.go
+++ b/pagination.go
@@ -6,8 +6,9 @@ import (
 )
 
 func PaginateInContext(ctx context.Context, req *request.Request, handlePage func(interface{}, bool) bool) error {
-	if err := InContext(ctx, req); err != nil {
+	if err := prepareContext(ctx, req); err != nil {
 		return err
 	}
+
 	return req.EachPage(handlePage)
 }

--- a/retryer_test.go
+++ b/retryer_test.go
@@ -7,14 +7,15 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/seiffert/ctxaws"
+	"github.com/mnussbaum/ctxaws"
 )
 
 func TestShouldRetry_ContextWithoutTimeout(t *testing.T) {
 	ctx := context.Background()
 
-	retryer := ctxaws.NewContextAwareRetryer(ctx)
+	retryer := ctxaws.NewContextAwareRetryer(ctx, client.DefaultRetryer{5})
 	req := &request.Request{
 		HTTPResponse: &http.Response{
 			StatusCode: http.StatusInternalServerError,
@@ -29,7 +30,7 @@ func TestShouldRetry_ContextAlreadyExceeded(t *testing.T) {
 	ctx, _ := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	time.Sleep(20 * time.Millisecond)
 
-	retryer := ctxaws.NewContextAwareRetryer(ctx)
+	retryer := ctxaws.NewContextAwareRetryer(ctx, client.DefaultRetryer{5})
 	req := &request.Request{}
 	if retryer.ShouldRetry(req) {
 		t.Error("Request should not be retried after context exceeded")
@@ -43,7 +44,7 @@ func TestShouldRetry_ContextWouldExpireWhileWaiting(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
-	retryer := ctxaws.NewContextAwareRetryer(ctx)
+	retryer := ctxaws.NewContextAwareRetryer(ctx, client.DefaultRetryer{5})
 	// a retry count of 10 causes a wait interval of ~58s
 	req := &request.Request{RetryCount: 10}
 	if retryer.ShouldRetry(req) {
@@ -51,5 +52,20 @@ func TestShouldRetry_ContextWouldExpireWhileWaiting(t *testing.T) {
 	}
 	if req.Error != ctxaws.ErrDeadlineWouldExceedBeforeRetry {
 		t.Errorf("Error should be '%s', not '%s'", ctxaws.ErrDeadlineWouldExceedBeforeRetry.Error(), req.Error)
+	}
+}
+
+func TestShouldRetry_RespectsConfiguredMaxRetries(t *testing.T) {
+	ctx := context.Background()
+
+	req := &request.Request{
+		HTTPResponse: &http.Response{
+			StatusCode: http.StatusInternalServerError,
+		},
+		Retryer: client.DefaultRetryer{1},
+	}
+	retryer := ctxaws.NewContextAwareRetryer(ctx, req.Retryer)
+	if retryer.MaxRetries() != 1 {
+		t.Errorf("Error max retries for ContextAwareRetryer should be 1 not %d", retryer.MaxRetries())
 	}
 }


### PR DESCRIPTION
The first page of paginated endpoints was being fetched twice.

By separating the context setup and the first fetch of the resource paginated endpoints are fetched as expected.
